### PR TITLE
Removed extra merge conflict stuff

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,13 +8,11 @@ endif
 if LIBGCRYPT
 include ../Makefile.libgcrypt.inc
 endif
-<<<<<<< HEAD
 if SECURETRANSPORT
 include ../Makefile.SecureTransport.inc
-=======
+endif
 if WINCNG
 include ../Makefile.WinCNG.inc
->>>>>>> master
 endif
 
 # Makefile.inc provides the CSOURCES and HHEADERS defines


### PR DESCRIPTION
When pulling from upstream, there was a merge conflict at some point. This commit removes the git conflict decoration and allows ./buildconf to work correctly.
